### PR TITLE
fix(unity/ios): resolve UnityFramework module for hosted (pub.dev) installs

### DIFF
--- a/engines/unity/dart/CHANGELOG.md
+++ b/engines/unity/dart/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the gameframework_unity package will be documented in this file.
 
+## [0.0.4] - 2026-06-26
+
+### Fixed
+- **iOS:** resolve the `UnityFramework` Swift module on hosted (pub.dev) installs.
+  The podspec's `FRAMEWORK_SEARCH_PATHS` used a single-`*` glob
+  (`.symlinks/plugins/*/ios`) that Xcode does not expand, so consumers of the
+  published package failed to build for iOS with
+  `Unable to resolve module dependency: 'UnityFramework'`. It only worked when
+  `game sync` planted a symlink in this pod's own directory — which never
+  happens for hosted installs. Switched to Xcode's recursive `**` search syntax,
+  which finds the consumer plugin's vendored `UnityFramework.framework` with no
+  `game sync` symlink and no Podfile workaround.
+
 ## [0.0.3] - 2026-02-06
 
 ### Changed

--- a/engines/unity/dart/ios/gameframework_unity.podspec
+++ b/engines/unity/dart/ios/gameframework_unity.podspec
@@ -42,8 +42,12 @@ to sync your Unity export to your plugin's ios/ directory.
   s.pod_target_xcconfig = { 
     'DEFINES_MODULE' => 'YES', 
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-    # Search for frameworks in the local directory (symlink), Pods build directory, and sibling plugins
-    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}" "${PODS_CONFIGURATION_BUILD_DIR}" "${PODS_ROOT}/../.symlinks/plugins/*/ios"',
+    # Find UnityFramework wherever the consumer plugin vendors it. NOTE: Xcode
+    # does NOT expand a single `*` in search paths, so "plugins/*/ios" never
+    # resolves for hosted (pub.dev) installs — it only worked when `game sync`
+    # planted a symlink in this pod's own dir. Use Xcode's recursive `**`
+    # syntax, which searches all subdirectories under the plugins symlink dir.
+    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}" "${PODS_CONFIGURATION_BUILD_DIR}" "${PODS_ROOT}/../.symlinks/plugins/**"',
     # Allow weak linking to UnityFramework
     'OTHER_LDFLAGS' => '$(inherited) -ObjC'
   }

--- a/engines/unity/dart/lib/src/unity_controller_web.dart
+++ b/engines/unity/dart/lib/src/unity_controller_web.dart
@@ -205,10 +205,8 @@ class UnityControllerWeb implements GameEngineController {
         'streamingAssetsUrl': '$buildUrl/StreamingAssets',
         'companyName':
             _getConfigValue<String>('companyName') ?? 'DefaultCompany',
-        'productName':
-            _getConfigValue<String>('productName') ?? 'Unity Game',
-        'productVersion':
-            _getConfigValue<String>('productVersion') ?? '1.0',
+        'productName': _getConfigValue<String>('productName') ?? 'Unity Game',
+        'productVersion': _getConfigValue<String>('productVersion') ?? '1.0',
       });
 
       _emitProgress(0.3);
@@ -336,7 +334,8 @@ class UnityControllerWeb implements GameEngineController {
           _makeEnvelope(msg.target, msg.method, msg.data),
         ]);
       } catch (e) {
-        debugPrint('Failed to flush queued message ${msg.target}.${msg.method}: $e');
+        debugPrint(
+            'Failed to flush queued message ${msg.target}.${msg.method}: $e');
       }
     }
   }
@@ -352,8 +351,7 @@ class UnityControllerWeb implements GameEngineController {
             'Unity WebGL message queue full ($_maxQueueSize). Dropped oldest message.');
       }
       _messageQueue.add(_QueuedMessage(target, method, data));
-      debugPrint(
-          'Unity WebGL not ready. Message queued: $target.$method '
+      debugPrint('Unity WebGL not ready. Message queued: $target.$method '
           '(${_messageQueue.length}/$_maxQueueSize)');
       return;
     }

--- a/engines/unity/dart/pubspec.yaml
+++ b/engines/unity/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gameframework_unity
 description: Unity Engine plugin for GameFramework. Provides Unity integration with bidirectional communication, AR Foundation support, and WebGL capabilities.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/xraph/gameframework
 repository: https://github.com/xraph/gameframework
 issue_tracker: https://github.com/xraph/gameframework/issues

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   gameframework: 0.0.3
 
   # Unity plugin
-  gameframework_unity: 0.0.3
+  gameframework_unity: 0.0.4
   
   # Unreal plugin
   gameframework_unreal: 0.0.3


### PR DESCRIPTION
## Description

`gameframework_unity`'s podspec set `FRAMEWORK_SEARCH_PATHS` to
`"${PODS_ROOT}/../.symlinks/plugins/*/ios"`, but Xcode does **not** expand a
single `*` glob in search paths. So the Swift compiler couldn't find the
`UnityFramework` module vendored by the consumer plugin, and any project
depending on the **published** package failed to build for iOS:

​```
Swift Compiler Error: Unable to resolve module dependency: 'UnityFramework'
import UnityFramework
​```

It only worked locally because `game sync` plants a symlink inside this pod's
own dir (`PODS_TARGET_SRCROOT`) — which never happens for hosted (pub.dev)
installs.

### Fix
Use Xcode's recursive `**` syntax, which resolves to the consumer plugin's
`ios/` dir regardless of plugin name — no `game sync` symlink, no Podfile hack:

​```diff
- "${PODS_ROOT}/../.symlinks/plugins/*/ios"
+ "${PODS_ROOT}/../.symlinks/plugins/**"
​```

### Verification
Built the `gameframework-unity-demo` example for an iOS device against the
hosted-style dependency with a **stock Podfile** and **no symlink** →
`✓ Built Runner.app`, with `UnityFramework` embedded and linked.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change