### PR TITLE
fix(podspec): recursive ** framework search path on Unity macOS + Unreal iOS

### DIFF
--- a/engines/unity/dart/macos/gameframework_unity.podspec
+++ b/engines/unity/dart/macos/gameframework_unity.podspec
@@ -42,8 +42,12 @@ to sync your Unity export to your plugin's macos/ directory.
   s.pod_target_xcconfig = { 
     'DEFINES_MODULE' => 'YES', 
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-    # Search for frameworks in the local directory (symlink), Pods build directory, and sibling plugins
-    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}" "${PODS_CONFIGURATION_BUILD_DIR}" "${PODS_ROOT}/../.symlinks/plugins/*/macos"',
+    # Find UnityFramework wherever the consumer plugin vendors it. NOTE: Xcode
+    # does NOT expand a single `*` in search paths, so "plugins/*/macos" never
+    # resolves for hosted (pub.dev) installs — it only worked when `game sync`
+    # planted a symlink in this pod's own dir. Use Xcode's recursive `**`
+    # syntax, which searches all subdirectories under the plugins symlink dir.
+    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}" "${PODS_CONFIGURATION_BUILD_DIR}" "${PODS_ROOT}/../.symlinks/plugins/**"',
     # Allow weak linking to UnityFramework
     'OTHER_LDFLAGS' => '$(inherited) -ObjC'
   }

--- a/engines/unreal/dart/ios/gameframework_unreal.podspec
+++ b/engines/unreal/dart/ios/gameframework_unreal.podspec
@@ -44,8 +44,12 @@ to sync your Unreal export to your plugin's ios/ directory.
   s.pod_target_xcconfig = { 
     'DEFINES_MODULE' => 'YES', 
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
-    # Search for frameworks in the local directory (symlink), Pods build directory, and sibling plugins
-    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}" "${PODS_CONFIGURATION_BUILD_DIR}" "${PODS_ROOT}/../.symlinks/plugins/*/ios"',
+    # Find UnrealFramework wherever the consumer plugin vendors it. NOTE: Xcode
+    # does NOT expand a single `*` in search paths, so "plugins/*/ios" never
+    # resolves for hosted (pub.dev) installs — it only worked when `game sync`
+    # planted a symlink in this pod's own dir. Use Xcode's recursive `**`
+    # syntax, which searches all subdirectories under the plugins symlink dir.
+    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "${PODS_TARGET_SRCROOT}" "${PODS_CONFIGURATION_BUILD_DIR}" "${PODS_ROOT}/../.symlinks/plugins/**"',
     # Allow weak linking to UnrealFramework
     'OTHER_LDFLAGS' => '$(inherited) -ObjC',
     'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES'


### PR DESCRIPTION
## Summary

Follow-up to #3, which fixed the Unity **iOS** podspec's `FRAMEWORK_SEARCH_PATHS` to use Xcode's recursive `**` glob. That fix was only applied to one of the engine podspecs the **Unity macOS** and **Unreal iOS** podspecs still used the single-`*` form (`.symlinks/plugins/*/<platform>`), which has the identical bug.

Xcode does **not** expand a single `*` in `FRAMEWORK_SEARCH_PATHS`, so `plugins/*/macos` (and `plugins/*/ios` for Unreal) never resolves the vendored engine framework for hosted (pub.dev) / standalone-app installs — it only worked when a symlink happened to be planted in the pod's own dir. Switching to `**` searches all subdirectories under the plugins symlink dir, matching the merged Unity-iOS fix.

## Changes

- `engines/unity/dart/macos/gameframework_unity.podspec`: `plugins/*/macos` → `plugins/**`
- `engines/unreal/dart/ios/gameframework_unreal.podspec`: `plugins/*/ios` → `plugins/**`

Comments updated to match the explanation already in the Unity iOS podspec.

## Notes

- The Unity iOS podspec (fixed in #3) and the `packages/gameframework` podspecs are unchanged.
- The Unreal macOS podspec has no `FRAMEWORK_SEARCH_PATHS` entry, so it's out of scope here.
