### PR TITLE
docs: Unreal mobile is live (Android + iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ dependencies:
   gameframework: ^0.0.3
   gameframework_unity: ^0.0.4  # If using Unity
   gameframework_stream: ^0.0.3  # If using asset streaming
-  # gameframework_unreal: ^0.0.3  # If using Unreal (WIP)
+  # gameframework_unreal: ^0.0.3  # If using Unreal
 ```
 
 ### Basic Usage
@@ -246,13 +246,15 @@ Game Engine (Unity/Unreal)
 - **Unity:** Android, iOS
 - **Core Framework:** All platforms
 
-### 🚧 Work in Progress
-- **Unity:** Web, macOS, Windows, Linux
+### 🟢 Working (Beta)
 - **Unreal:** Android, iOS
 
+### 🚧 Work in Progress
+- **Unity:** Web, macOS, Windows, Linux
+
 ### 📋 Roadmap
+- Harden Unreal Engine mobile integration
 - Complete Unity desktop & web support
-- Complete Unreal Engine mobile integration
 - Unreal desktop & web support
 - Advanced streaming features
 - Performance optimization tools
@@ -262,8 +264,8 @@ Game Engine (Unity/Unreal)
 
 | Platform | gameframework | Unity | Unreal | Status |
 |----------|--------------|-------|--------|--------|
-| Android  | ✅ Ready     | ✅ Ready | 🚧 WIP | Stable |
-| iOS      | ✅ Ready     | ✅ Ready | 🚧 WIP | Stable |
+| Android  | ✅ Ready     | ✅ Ready | 🟢 Beta | Stable |
+| iOS      | ✅ Ready     | ✅ Ready | 🟢 Beta | Stable |
 | Web      | ✅ Ready     | ✅ Ready | ⏳ Planned | Stable   |
 | macOS    | ✅ Ready     | 🚧 WIP | ⏳ Planned | Beta   |
 | Windows  | ✅ Ready     | 🚧 WIP | ⏳ Planned | Beta   |


### PR DESCRIPTION
Unreal Engine now runs embedded in Flutter on **Android + iOS** (demoed live on device). Updating the docs to match:

- Move **Unreal: Android, iOS** from *Work in Progress* → **Working (Beta)**.
- Platform table: Unreal Android/iOS `🚧 WIP` → `🟢 Beta`.
- Drop the `(WIP)` note on the `gameframework_unreal` dependency snippet.

Desktop/web for both engines remain genuinely WIP and are unchanged. (Repo About description updated separately to drop 'Unreal Engine(WIP)'.)